### PR TITLE
Add support for Alpine 3.21 and s6-overlay 3.2.0.2

### DIFF
--- a/.github/workflows/update-keepalivd-version.yml
+++ b/.github/workflows/update-keepalivd-version.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Fetch release version
         id: fetch-release
         run: |
-          wget https://git.alpinelinux.org/aports/plain/community/keepalived/APKBUILD?h=3.20-stable -O APKBUILD
+          wget https://git.alpinelinux.org/aports/plain/community/keepalived/APKBUILD?h=3.21-stable -O APKBUILD
           source APKBUILD
           rm -f APKBUILD
           KEEPALIVED_VERSION="${pkgver}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@
 #
 
 # Set alpine image version
-ARG ALPINE_VERSION="3.20"
+ARG ALPINE_VERSION="3.21"
 
 # Set vars for s6 overlay
-ARG S6_OVERLAY_VERSION="v3.2.0.0"
+ARG S6_OVERLAY_VERSION="v3.2.0.2"
 ARG S6_OVERLAY_BASE_URL="https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}"
 ARG S6_OVERLAY_NOARCH="${S6_OVERLAY_BASE_URL}/s6-overlay-noarch.tar.xz"
 


### PR DESCRIPTION
- Bump Alpine from 3.20 to 3.21
  - This will update keepalived from 2.2.8 to 2.3.2
  - Release notes can be found here https://www.keepalived.org/release-notes/Release-2.3.2.html
- Bump s6-overlay to 3.2.0.2
