### PR TITLE
fix ignore @ appendix in interface names

### DIFF
--- a/rootfs/etc/s6-overlay/s6-rc.d/init-keepalived-config/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/init-keepalived-config/run
@@ -35,7 +35,7 @@ else
         exit 1
     fi
     # Check if given interface is available
-    IFS=$'\n' read -r -d '' -a available_interfaces < <(ip -br link show | awk '$1 !~ "lo|vir|docker|veth|br-" { print $1 }' && printf '\0')
+    IFS=$'\n' read -r -d '' -a available_interfaces < <(ip -br link show | awk '$1 !~ "lo|vir|docker|veth|br-" { print $1 }' | cut -d '@' -f1 && printf '\0')
     if ! [[ " ${available_interfaces[*]} " =~ " ${KEEPALIVED_INTERFACE} " || "${KEEPALIVED_INTERFACE}" == "auto" ]]; then
         echo "The KEEPALIVED_INTERFACE environment variable contains a non-existent interface \"${KEEPALIVED_INTERFACE}\". Available interfaces are: ${available_interfaces[*]}. Exiting..."
         exit 1


### PR DESCRIPTION
# Summary

interfaces names with @ are not handled correctly: The @ symbol within a network interface name (e.g., eth0@10) indicates a relationship with another interface, but it's not a part of the interface's official name.

# Problem

The `KEEPALIVED_INTERFACE` environment variable contains a non-existent interface "eth0". Available interfaces are: eth0@if6. Exiting...

```
 # ip -br link show | awk '$1 !~ "lo|vir|docker|veth|br-" { print $1 }' && printf '\0'
eth0@if26
```


# Expected

The check should ignore the @ appendix

# Possible Solution

```
ip -br link show | awk '$1 !~ "lo|vir|docker|veth|br-" { print $1 }' | cut -d '@' -f1 && printf '\0'
eth0
```
also works with interface names without the `@` appendix:

```
echo eth0 | cut -d '@' -f1
eth0
```
