### PR TITLE
fix: ignore @ appendix in interface names when KEEPALIVED_INTERFACE i…

### DIFF
--- a/rootfs/etc/s6-overlay/s6-rc.d/init-keepalived-config/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/init-keepalived-config/run
@@ -51,7 +51,7 @@ else
 
             if [[ "$KEEPALIVED_VIRTUAL_MASK" == "$interface_mask" ]] && [[ "$vip_network" == "$interface_network" ]]; then
                 echo "Found interface $interface_name for $KEEPALIVED_VIRTUAL_IP/$KEEPALIVED_VIRTUAL_MASK"
-                export KEEPALIVED_INTERFACE="$interface_name"
+                export KEEPALIVED_INTERFACE="$(cut -d '@' -f1 <<< "$interface_name")"
                 break
             fi
         done < <(ip -br addr show | awk '$1 !~ "lo|vir|docker|veth|br-" { print $1"_"$3 }')


### PR DESCRIPTION
Adds to the recent interface name @ifX fix and sets the actual interface name when KEEPALIVED_INTERFACE is auto.