### PR TITLE
fix: escape ampersands in check script

### DIFF
--- a/rootfs/etc/s6-overlay/s6-rc.d/init-keepalived-config/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/init-keepalived-config/run
@@ -10,7 +10,7 @@ else
         if [[ -z ${KEEPALIVED_CHECK_IP} ]] || [[ ${KEEPALIVED_CHECK_IP} = 'any' ]]; then
             KEEPALIVED_CHECK_SCRIPT="iptables -t nat -nL CATTLE_PREROUTING | grep ':${KEEPALIVED_CHECK_PORT}'"
         else
-            KEEPALIVED_CHECK_SCRIPT="iptables -nL | grep '${KEEPALIVED_CHECK_IP}' && iptables -t nat -nL CATTLE_PREROUTING | grep ':${KEEPALIVED_CHECK_PORT}'"
+            KEEPALIVED_CHECK_SCRIPT="iptables -nL | grep '${KEEPALIVED_CHECK_IP}' \&\& iptables -t nat -nL CATTLE_PREROUTING | grep ':${KEEPALIVED_CHECK_PORT}'"
         fi
     fi
     # Make sure the variables we need to run are populated and (roughly) valid


### PR DESCRIPTION
Without these ampersands escaped, I've seen issues after a deploy where the container would not come up cleanly. It seems this was due to the `sed` for replacing the `CHECK_SCRIPT` not paying nicely with the ampersands in the `KEEPALIVED_CHECK_SCRIPT`. The replaced text would appear as: `iptables -nL | grep '192.168.1.5' {{CHECK_SCRIPT}}{{CHECK_SCRIPT}} iptables -t nat -nL CATTLE_PREROUTING | grep ':53'`.